### PR TITLE
Update Census geocoder vintage parameter to Current_Current.

### DIFF
--- a/R/geocode.R
+++ b/R/geocode.R
@@ -133,7 +133,7 @@ census_geocode_params <- function(...) {
 
   params <- list(format='json',
                  benchmark='Public_AR_Current',
-                 vintage='ACS2015_Current',
+                 vintage='Current_Current',
                  layers=paste(default_layers, collapse=','))
   list_modify(params, ...)
 }


### PR DESCRIPTION
The ACS2015_Current vintage is no longer available from the geocoder, so
requests will error out. The Current_Current vintage is probably a better
setting for this package anyway.